### PR TITLE
Convert timestamp columns to datetime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 ### Fixed
 - Allowing negative sales amount to be stored in the database.
 
+### Changed
+- All timestamp database columns converted to datetime.
+
 ## [0.1.0] – 2024-04-18
 
 ### Added

--- a/database/migrations/2024_01_22_100000_ragnarok_fara_arch_table.php
+++ b/database/migrations/2024_01_22_100000_ragnarok_fara_arch_table.php
@@ -14,7 +14,7 @@ return new class extends Migration
         Schema::create('fara_arch', function (Blueprint $table)
         {
             $table->unsignedBigInteger('transactionida')->comment('Transaction ID. PS: Duplicates allowed');
-            $table->timestamp('eventdatetime')->comment('Date/time');
+            $table->timestamp('eventdatetime')->comment('Date/time of event');
             $table->unsignedBigInteger('operatorcompanyid')->comment('Reference: fara_company.companyid');
             $table->unsignedBigInteger('operatorid')->comment('Operator ID');
             $table->integer('producttemplateno')->comment('Reference: fara_basic_template.templateid');

--- a/database/migrations/2024_06_14_130000_ragnarok_fara_date_time.php
+++ b/database/migrations/2024_06_14_130000_ragnarok_fara_date_time.php
@@ -26,6 +26,17 @@ return new class extends Migration
         //
     }
 
+    /**
+     * Convert a db column from TIMESTAMP to DATETIME.
+     *
+     * Unfortunately Laravel's ->change() doesn't take on this kind of
+     * conversion so it have to be done manually:
+     * 1) Rename original column to ..._old
+     * 2) Create new DATETIME column with same name as original.
+     * 3) Copy data from original to new column (No need for conversion as this
+     *    is handled by mysql/mariadb)
+     * 4) Drop original, renamed column
+     */
     protected function timestampToDatetime(string $tableName, string $columnName, string $comment, $nullable = true)
     {
         Schema::table($tableName, function (Blueprint $table) use ($columnName){

--- a/database/migrations/2024_06_14_130000_ragnarok_fara_date_time.php
+++ b/database/migrations/2024_06_14_130000_ragnarok_fara_date_time.php
@@ -12,10 +12,10 @@ return new class extends Migration
      */
     public function up(): void
     {
-        $this->timestampToDatetime('fara_stat_load', 'lastupdated', 'Last updated. Date/time');
+        $this->timestampToDatetime('fara_stat_load', 'lastupdated', 'Last updated. Date/time', false);
         $this->timestampToDatetime('fara_stat_traffic_cust_profile', 'lastupdated', 'Last updated. Date/time');
         $this->timestampToDatetime('fara_stat_traffic_income', 'lastupdated', 'Last updated. Date/time');
-        $this->timestampToDatetime('fara_arch', 'eventdatetime', 'Date/time of event');
+        $this->timestampToDatetime('fara_arch', 'eventdatetime', 'Date/time of event', false);
     }
 
     /**
@@ -26,7 +26,7 @@ return new class extends Migration
         //
     }
 
-    protected function timestampToDatetime(string $tableName, string $columnName, string $comment)
+    protected function timestampToDatetime(string $tableName, string $columnName, string $comment, $nullable = true)
     {
         Schema::table($tableName, function (Blueprint $table) use ($columnName){
             $table->renameColumn($columnName, $columnName . '_old');
@@ -37,6 +37,12 @@ return new class extends Migration
         });
 
         DB::table($tableName)->update([$columnName => DB::raw($columnName . '_old')]);
+
+        if (!$nullable) {
+            Schema::table($tableName, function (Blueprint $table) use ($columnName, $comment) {
+                $table->dateTime($columnName)->nullable(false)->comment($comment)->change();
+            });
+        }
 
         Schema::table($tableName, function (Blueprint $table) use ($columnName) {
             $table->dropColumn($columnName . '_old');

--- a/database/migrations/2024_06_14_130000_ragnarok_fara_date_time.php
+++ b/database/migrations/2024_06_14_130000_ragnarok_fara_date_time.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        $this->timestampToDatetime('fara_stat_load', 'lastupdated', 'Last updated. Date/time');
+        $this->timestampToDatetime('fara_stat_traffic_cust_profile', 'lastupdated', 'Last updated. Date/time');
+        $this->timestampToDatetime('fara_stat_traffic_income', 'lastupdated', 'Last updated. Date/time');
+        $this->timestampToDatetime('fara_arch', 'eventdatetime', 'Date/time of event');
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        //
+    }
+
+    protected function timestampToDatetime(string $tableName, string $columnName, string $comment)
+    {
+        Schema::table($tableName, function (Blueprint $table) use ($columnName){
+            $table->renameColumn($columnName, $columnName . '_old');
+        });
+
+        Schema::table($tableName, function (Blueprint $table) use ($columnName, $comment) {
+            $table->dateTime($columnName)->nullable()->after($columnName . '_old')->comment($comment);
+        });
+
+        DB::table($tableName)->update([$columnName => DB::raw($columnName . '_old')]);
+
+        Schema::table($tableName, function (Blueprint $table) use ($columnName) {
+            $table->dropColumn($columnName . '_old');
+        });
+    }
+};


### PR DESCRIPTION
Ok.

Mysql defines `TIMESTAMP` columns as seconds since unix epoch (1. jan 1970). The stored value is seconds in UTC. What it does not say is that it converts the value between this and ISO date between saving and retrieval, so for any client using this value it appears and behaves exactly like an ISO date.  With limitations of not being able to be outside the range 1970 – 2038.

The laravel migration `->change()` method does not allow the switch between `->timestamp()` and `->dateTime()`, so the migration has to be done manually:
- Rename the old column to ..._old
- Create new column in place of the old
- Copy data 1:1 from old to new
- Drop old column

There is no magic done here. No need to meddle with timezones as this is handled by mysql/mariadb.